### PR TITLE
Added support for Microchip SST26VF016B SST26VF032B chips.

### DIFF
--- a/src/SPIFlash.cpp
+++ b/src/SPIFlash.cpp
@@ -82,6 +82,7 @@ bool SPIFlash::begin(uint32_t flashChipSize) {
   bool retVal = _chipID(flashChipSize);
   _endSPI();
   chipPoweredDown = false;
+  _disableGlobalBlockProtect();
   return retVal;
 }
 

--- a/src/SPIFlash.h
+++ b/src/SPIFlash.h
@@ -193,11 +193,11 @@ private:
   uint32_t    _addressOverflow = false;
   uint32_t    _BasicParamTableAddr, _SectorMapParamTableAddr, _byteFirstPrgmTime, _byteAddnlPrgmTime, _pagePrgmTime;
   uint8_t     _uniqueID[8];
-  const uint8_t _capID[16]   =
-  {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x43, 0x4B, 0x00, 0x01, 0x13, 0x37};
+  const uint8_t _capID[18]   =
+  {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x41, 0x42, 0x43, 0x4B, 0x00, 0x01, 0x13, 0x37};
 
-  const uint32_t _memSize[16]  =
-  {KB(64), KB(128), KB(256), KB(512), MB(1), MB(2), MB(4), MB(8), MB(16), MB(32), MB(8), MB(8), KB(256), KB(512), MB(4), KB(512)};
+  const uint32_t _memSize[18]  =
+  {KB(64), KB(128), KB(256), KB(512), MB(1), MB(2), MB(4), MB(8), MB(16), MB(32), MB(2), MB(4), MB(8), MB(8), KB(256), KB(512), MB(4), KB(512)};
   // To understand the _memSize definitions check defines.h
 
   const uint8_t _supportedManID[7] = {WINBOND_MANID, MICROCHIP_MANID, CYPRESS_MANID, ADESTO_MANID, MICRON_MANID, ON_MANID, AMIC_MANID};


### PR DESCRIPTION
![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Marzogh/SPIMemory/144.svg)
###### ---------------------------- **DO NOT DELETE OR EDIT** anything above this line ----------------------------

Hey there! Thanks for using the SPIFlash library for Arduino.
### Please note that starting 01.03.2018 any Pull request raised here MUST be submitted according to this template or it will be flagged with 'Not enough information'. No action will be taken till all the prerequisite information is provided. If no information is provided for over a month, the pull request will be closed.

# Pull request details

* **Please check if the PR fulfills these requirements**
- [x] The commit message/s explain/s all the changes clearly


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bug fix
- [x] Other - Please explain here:
Added "out of box" support for two new chip SST26VF016B and SST26VF032B. I tested it only with SST26VF016B, but think that SST26VF032B can't fail too. 
The second is a fix that actually disables Global Block Protection at the library initialisation. Function _disableGlobalBlockProtect was there before, but never called.


* **What is the current behavior?** (You can also link to an open issue here)
Writing to the SST26VF0xxB does not work. It looks like everything is ok, but actually write doesn't perform.


* **What is the new behavior (if this is a feature change)?**
I just add _disableGlobalBlockProtect function call at the end of "begin".


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Thank you for your work! ;)