### PR TITLE
Fix a bug where multi-sector writes will be prefixed by FF FF FF FF

### DIFF
--- a/src/SPIFlash.h
+++ b/src/SPIFlash.h
@@ -318,11 +318,11 @@ template <class T> bool SPIFlash::_write(uint32_t _addr, const T& value, uint32_
   if (!SPIBusState) {
     _startSPIBus();
   }
-  CHIP_SELECT
-  _nextByte(WRITE, PAGEPROG);
-  _transferAddress();
 
   if (maxBytes > length) {
+    CHIP_SELECT
+    _nextByte(WRITE, PAGEPROG);
+    _transferAddress();
     for (uint16_t i = 0; i < length; ++i) {
       _nextByte(WRITE, *p++);
     }


### PR DESCRIPTION
This change moves the first chip select, mode write, and address write into the less-than-one-sector write case. If this is not done the chip select, mode write, and address write will be done twice for the first sector of a multi-sector write.

# Pull request details

* **Please check if the PR fulfils these requirements**
- [x] The commit message/s explain/s all the changes clearly
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bug fix
- [ ] Added feature
- [ ] Documentation update
- [ ] Other - Please explain here:
