### PR TITLE
WIP:Pr fix stm32 defines

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This Arduino library is for use with flash and FRAM memory chips that communicat
 | ATSAMD51J19 (ARM Cortex M4) | Adafruit Metro M4 | - |
 | STM32F091RCT6 | Nucleo-F091RC | |
 | STM32L0 | Nucleo-L031K6 | |
+| STM32F4 | STM32F407VET6 | |
 | ESP8266 | Adafruit ESP8266 Feather, <br> Sparkfun ESP8266 Thing | - |
 | ESP32 | Adafruit ESP32 Feather, <br> Sparkfun ESP32 Thing | Onboard flash memory. Refer to footnote<sup>£</sup> below. |
 | Simblee | Sparkfun Simblee | - |
@@ -46,7 +47,7 @@ This Arduino library is for use with flash and FRAM memory chips that communicat
 
 | Manufacturer | Flash IC | Notes |
 | ------------ | -------- | ----- |
-| Winbond | W25Q16BV <br> W25Q64FV <br> W25Q64JV <br> W25Q80BV <br> W25Q256FV | Should work with the W25QXXXBV, W25QXXXFV & <br> W25QXXXJV families |
+| Winbond | W25Q16BV <br> W25Q64FV <br> W25Q64JV <br> W25Q80BV <br> W25Q256FV <br> W25Q16JV| Should work with the W25QXXXBV, W25QXXXFV & <br> W25QXXXJV families |
 | Microchip | SST25VF064C <br> SST26VF016B <br> SST26VF032B <br> SST26VF064B | Should work with the SST25 & SST26 families |
 | Cypress/Spansion | S25FL032P <br> S25FL116K <br> S25FL127S | Should work with the S25FL family |
 | ON Semiconductor | LE25U40CMC |  |

--- a/src/SPIFlashIO.cpp
+++ b/src/SPIFlashIO.cpp
@@ -154,7 +154,7 @@
 
    #if defined (ARDUINO_ARCH_SAM)
      due.SPIInit(DUE_SPI_CLK);
-   #elif defined (ARDUINO_ARCH_SAMD)
+   #elif defined (ARDUINO_ARCH_SAMD) || defined(ARCH_STM32)
      #ifdef SPI_HAS_TRANSACTION
        _spi->beginTransaction(_settings);
      #else
@@ -231,7 +231,7 @@
 
  //Reads/Writes next byte. Call 'n' times to read/write 'n' number of bytes. Should be called after _beginSPI()
  uint8_t SPIFlash::_nextByte(char IOType, uint8_t data) {
- #if defined (ARDUINO_ARCH_SAMD)
+ #if defined (ARDUINO_ARCH_SAMD) || defined(ARCH_STM32)
    #ifdef ENABLEZERODMA
      union {
        uint8_t dataBuf[1];
@@ -250,7 +250,7 @@
 
  //Reads/Writes next int. Call 'n' times to read/write 'n' number of integers. Should be called after _beginSPI()
  uint16_t SPIFlash::_nextInt(uint16_t data) {
- #if defined (ARDUINO_ARCH_SAMD)
+ #if defined (ARDUINO_ARCH_SAMD) || defined(ARCH_STM32)
    return _spi->transfer16(data);
  #else
    return SPI.transfer16(data);
@@ -267,7 +267,7 @@
      case READDATA:
      #if defined (ARDUINO_ARCH_SAM)
        due.SPIRecByte(&(*data_buffer), size);
-     #elif defined (ARDUINO_ARCH_SAMD)
+     #elif defined (ARDUINO_ARCH_SAMD) || defined(ARCH_STM32)
        #ifdef ENABLEZERODMA
          spi_read(&(*data_buffer), size);
        #else
@@ -286,7 +286,7 @@
      case PAGEPROG:
      #if defined (ARDUINO_ARCH_SAM)
        due.SPISendByte(&(*data_buffer), size);
-     #elif defined (ARDUINO_ARCH_SAMD)
+     #elif defined (ARDUINO_ARCH_SAMD) || defined(ARCH_STM32)
        #ifdef ENABLEZERODMA
          spi_write(&(*data_buffer), size);
        #else
@@ -313,7 +313,7 @@
    }
 
  #ifdef SPI_HAS_TRANSACTION
-   #if defined (ARDUINO_ARCH_SAMD)
+   #if defined (ARDUINO_ARCH_SAMD) || defined(ARCH_STM32)
      _spi->endTransaction();
    #else
      SPI.endTransaction();

--- a/src/SPIMemory.h
+++ b/src/SPIMemory.h
@@ -69,12 +69,32 @@
 //#define ZERO_SPISERCOM SERCOM4                                      //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-  #include <Arduino.h>
-  #include <SPI.h>
-  #include "defines.h"
-  #include "SPIFlash.h"
-  #include "SPIFram.h"
-  #include "diagnostics.h"
+#ifndef ARCH_STM32
+  #if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_STM32L0) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F0xx)
+    #define ARCH_STM32
+  #endif
+#endif
+#if defined (ARDUINO_ARCH_SAM) || defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_ARCH_ESP8266) || defined (SIMBLEE) || defined (ARDUINO_ARCH_ESP32) || defined (BOARD_RTL8195A) || defined(ARCH_STM32) || defined(ESP32) || defined(NRF52)
+// RTL8195A included - @boseji <salearj@hotmail.com> 02.03.17
+  #define _delay_us(us) delayMicroseconds(us)
+#else
+  #include <util/delay.h>
+#endif
+
+#define SPIFLASH_LIBVER 3
+#define SPIFLASH_LIBSUBVER 4
+#define SPIFLASH_REVVER 0
+
+#define SPIFRAM_LIBVER 0
+#define SPIFRAM_LIBSUBVER 0
+#define SPIFRAM_REVVER 1
+
+#include <Arduino.h>
+#include <SPI.h>
+#include "defines.h"
+#include "SPIFlash.h"
+#include "SPIFram.h"
+#include "diagnostics.h"
 
 #if defined (ARDUINO_ARCH_SAM)
   #include <malloc.h>
@@ -102,25 +122,6 @@
   #endif
 #endif
 
-#ifndef ARCH_STM32
-  #if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_STM32L0) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F0xx)
-    #define ARCH_STM32
-  #endif
-#endif
-#if defined (ARDUINO_ARCH_SAM) || defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_ARCH_ESP8266) || defined (SIMBLEE) || defined (ARDUINO_ARCH_ESP32) || defined (BOARD_RTL8195A) || defined(ARCH_STM32) || defined(ESP32) || defined(NRF52)
-// RTL8195A included - @boseji <salearj@hotmail.com> 02.03.17
-  #define _delay_us(us) delayMicroseconds(us)
-#else
-  #include <util/delay.h>
-#endif
-
-#define SPIFLASH_LIBVER 3
-#define SPIFLASH_LIBSUBVER 4
-#define SPIFLASH_REVVER 0
-
-#define SPIFRAM_LIBVER 0
-#define SPIFRAM_LIBSUBVER 0
-#define SPIFRAM_REVVER 1
 
 class SPIMemory {
 public:


### PR DESCRIPTION
# Pull request details

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ x] Bug fix
- [ x] Added feature
- [ x] Documentation update

* **What is the current behavior?** (You can also link to an open issue here)
Using this development board: https://stm32-base.org/boards/STM32F407VET6-STM32-F4VE-V2.0.html#User-LED-1
![image](https://user-images.githubusercontent.com/9113272/204301500-f4d727f6-b2cb-40dd-8a87-1078b48aef30.png)

The stm32 defines needed updated.

This example code wouldn't compile:
```
#include "Arduino.h"
#include <SPI.h>
#include <SPIMemory.h>

#define MISO PB4
#define MOSI PB5
#define SCK  PB3
#define CS   PB0
SPIClass spiclass(MOSI, MISO, SCK);

SPIFlash flash(CS, &spiclass);

void setup() {
  SerialUSB.begin(115200);
  flash.begin(MB(2));
}

void loop() {
  uint16_t manID = flash.getJEDECID();
  SerialUSB.printf("manID %i \n\r", manID);
  delay(2000);
}
```
Due to  SPIFlash.h being included before AARCH_STM32 was defined the code wouldn't compile:
```
src/main.cpp:11:29: error: no matching function for call to 'SPIFlash::SPIFlash(int, SPIClass*)'
   11 | SPIFlash flash(CS, &spiclass);
      |                             ^
In file included from .pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIMemory.h:75,
                 from src/main.cpp:3:
.pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIFlash.h:42:3: note: candidate: 'SPIFlash::SPIFlash(int8_t*)'
   42 |   SPIFlash(int8_t *SPIPinsArray);
      |   ^~~~~~~~
.pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIFlash.h:42:3: note:   candidate expects 1 argument, 2 provided
.pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIFlash.h:41:3: note: candidate: 'SPIFlash::SPIFlash(uint8_t)'
   41 |   SPIFlash(uint8_t cs = CS);
      |   ^~~~~~~~
.pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIFlash.h:41:3: note:   candidate expects 1 argument, 2 provided
.pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIFlash.h:32:7: note: candidate: 'constexpr SPIFlash::SPIFlash(const SPIFlash&)'
   32 | class SPIFlash {
      |       ^~~~~~~~
.pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIFlash.h:32:7: note:   candidate expects 1 argument, 2 provided
.pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIFlash.h:32:7: note: candidate: 'constexpr SPIFlash::SPIFlash(SPIFlash&&)'
.pio/libdeps/genericSTM32F407VET6/SPIMemory/src/SPIFlash.h:32:7: note:   candidate expects 1 argument, 2 provided
*** [.pio/build/genericSTM32F407VET6/src/main.cpp.o] Error 1
```

Also since this example is using a non-standard SPIClass, more ARCH_STM32 were needed so that the SPIFlash _spi object would be used instead of the generic SPI object

* **What is the new behavior?** (if this is a feature change)
Adds support for more STM32 boards like the one mentioned above.

* **Other information**:

<hr>

###### DO NOT DELETE OR EDIT anything below this

<hr>

<sub> <b> Note 1: _Make sure to add **all the information needed to understand the bug** so that someone can help. If any essential information is missing we'll add the 'Needs more information' label and close the issue until there is enough information._ </b></sub>

<sub> <b> Note 2: For support questions (for example, tutorials on how to use the library), please use the [Arduino Forums](http://forum.arduino.cc/index.php?topic=324009.0). This repository's issues are reserved for feature requests and bug reports. </b></sub>

<hr>

![GitHub issue state](https://img.shields.io/github/issues/detail/s/Marzogh/SPIFlash/14.svg) ![GitHub issue title](https://img.shields.io/github/issues/detail/title/Marzogh/SPIFlash/14.svg) ![GitHub issue author](https://img.shields.io/github/issues/detail/u/Marzogh/SPIFlash/14.svg) ![GitHub issue label](https://img.shields.io/github/issues/detail/label/Marzogh/SPIFlash/14.svg) ![GitHub issue comments](https://img.shields.io/github/issues/detail/comments/Marzogh/SPIFlash/14.svg) ![GitHub issue age](https://img.shields.io/github/issues/detail/age/Marzogh/SPIFlash/14.svg) ![GitHub issue last update](https://img.shields.io/github/issues/detail/last-update/Marzogh/SPIFlash/14.svg)![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Marzogh/SPIFlash/14.svg)
